### PR TITLE
Bumped configurator to 0.3 and removed redundant imports

### DIFF
--- a/snap-extras.cabal
+++ b/snap-extras.cabal
@@ -1,5 +1,5 @@
 Name:                snap-extras
-Version:             0.9.1
+Version:             0.9.2
 Synopsis:            A collection of useful helpers and utilities for Snap web applications.
 Description:         This package contains a collection of helper functions
                      that come in handy in most practical, real-world
@@ -44,7 +44,7 @@ Library
     , blaze-builder            >= 0.3   && < 0.4
     , blaze-html               >= 0.6   && < 0.8
     , bytestring               >= 0.9.1 && < 0.11
-    , configurator             >= 0.2   && < 0.3
+    , configurator             >= 0.2   && < 0.4
     , containers               >= 0.3   && < 0.6
     , data-default             >= 0.5   && < 0.6
     , digestive-functors       >= 0.3   && < 0.8

--- a/src/Snap/Extras/PollStatus.hs
+++ b/src/Snap/Extras/PollStatus.hs
@@ -102,8 +102,6 @@ import           Control.Applicative
 import           Control.Error
 import           Control.Monad.Trans
 import           Data.ByteString                (ByteString)
-import qualified Data.ByteString.Char8          as B
-import           Data.Maybe
 import           Data.Monoid
 import           Data.Readable
 import           Data.Text
@@ -112,15 +110,11 @@ import           Data.Text.Encoding
 import           Data.Time
 import           Heist
 import           Heist.Compiled
-import           Heist.SpliceAPI
 import           Heist.Splices
 import           Language.Javascript.JMacro
-import           Safe
 import           Snap.Core
-import           Snap.Extras.CoreUtils
 import           Snap.Snaplet
-import           Snap.Snaplet.Heist.Compiled    (HasHeist, render,
-                                                 withHeistState)
+import           Snap.Snaplet.Heist.Compiled    (HasHeist)
 import           Text.PrettyPrint.Leijen.Text   (renderOneLine)
 import qualified Text.XmlHtml                   as X
 ------------------------------------------------------------------------------


### PR DESCRIPTION
Hello folks,

hope life is good in NYC :)
I've release the constrain on configurator, so it builds with 0.3, and removed a bunch of redundant imports.

I have also already bumped the version of the package.

Alfredo
