### PR TITLE
Bumps aeson upperbound to < 0.9

### DIFF
--- a/snap-extras.cabal
+++ b/snap-extras.cabal
@@ -45,7 +45,7 @@ Library
 
   hs-source-dirs: src
   Build-depends:
-      aeson                    >= 0.6   && < 0.8
+      aeson                    >= 0.6   && < 0.9
     , base                     >= 4     && < 5
     , blaze-builder            >= 0.3   && < 0.4
     , blaze-html               >= 0.6   && < 0.8


### PR DESCRIPTION
I see the upperbound was bumped and then retracted in 657e03b8fe7392c212bf with the comment "Oops, can't test with aeson yet".

I "tested" it insofar as I built, ran my stuff, threw some random stuff at it... didn't see any problems. Also, looking at the [changes between 0.7.0.6 and 0.8.0.0](https://github.com/bos/aeson/compare/0.7.0.6...0.8.0.0) it seems relatively benign and unrelated to anything happening in snap-extras... were it not for dropping earlier BS version support it could almost be a subminor version change rather than minor.

Anyways, if there's some specific testing you think is prudent, let me know and I'd be happy to help with it. Having this upperbound increased would help me avoid some dependency issues (e.g. with the new [criterion version 1](https://hackage.haskell.org/package/criterion)).