### PR TITLE
loosen aeson bounds to 0.9-compatible 0.11

### DIFF
--- a/snap-extras.cabal
+++ b/snap-extras.cabal
@@ -46,7 +46,7 @@ Library
 
   hs-source-dirs: src
   Build-depends:
-      aeson                    >= 0.6   && < 0.11
+      aeson                    >= 0.6   && < 0.12
     , base                     >= 4     && < 5
     , blaze-builder            >= 0.3   && < 0.5
     , blaze-html               >= 0.6   && < 0.9


### PR DESCRIPTION
0.11 is meant to be compatible with 0.9 (rolling back some undesireable changes in 0.10) so this should be compatible with the current bounds which allow both 0.9 and 0.10.
