### PR TITLE
Adds stack.yaml.lock to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist
 TAGS
 poll-example/log
 .stack-work/
+stack.yaml.lock


### PR DESCRIPTION
This file should either be committed to the repo or added to the `.gitignore`.

Since it's not here, I'm going to assume that it should probably be ignored and I've updated the `.gitignore` accordingly.